### PR TITLE
Add Support for "colourblind safe" palette creation

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -2,5 +2,6 @@ Glasbey API Reference
 =====================
 
 .. automodule:: glasbey
+   :imported-members:
    :members: create_palette, extend_palette, create_block_palette
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -2,3 +2,4 @@ Glasbey API Reference
 =====================
 
 .. automodule:: glasbey
+   :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,6 +1,8 @@
 Glasbey API Reference
 =====================
 
+Glasbey consist of three major functions, documented here.
+
 .. automodule:: glasbey
    :imported-members:
    :members: create_palette, extend_palette, create_block_palette

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -1,0 +1,4 @@
+Glasbey API Reference
+=====================
+
+.. automodule:: glasbey

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -2,7 +2,5 @@ Glasbey API Reference
 =====================
 
 .. automodule:: glasbey
-   :members:
+   :members: create_palette, extend_palette, create_block_palette
 
-.. automodule:: glasbey._glasbey
-   :members:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -3,3 +3,6 @@ Glasbey API Reference
 
 .. automodule:: glasbey
    :members:
+
+.. automodule:: glasbey._glasbey
+   :members:

--- a/doc/color_vision_deficiency.ipynb
+++ b/doc/color_vision_deficiency.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "35da7799-c870-40e1-bde7-4ba68e890c90",
+   "metadata": {},
+   "source": [
+    "# Colour-blind Safe Palettes\n",
+    "\n",
+    "Colour vision deficiency (a.k.a colour-blindness) is a condition that can effect upward of 5% of the population, and often results in difficulty percieving distinctions between some colours. The most common kinds of colour vision deficiency result in difficulty percieving differences between colours in the re-green range. Glasbey offers some features that can help make created or extended colour palettes more easily distinguished by those with some degree of colour vision deficiency. \n",
+    "\n",
+    "It should be noted that the methods used in Glasbey can at best aid in the creation of palettes that are *more* accessible to individuals with colour vision deficiency. Just as a large enough palette will result in some colours that are hard to distinguish without colour vision deficiency, even using the options described here cannot ensure that individuals with colour vision deficiency will not have any difficulty distinguishing among colours in the palettes created.\n",
+    "\n",
+    "To demonstrate some examples of palettes that are more assessible to individuals with colour vision deficiency we'll need to import glasbey, and to visualize the colour palettes we'll use seaborn."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d97ecaf8-f8d6-4c4b-b08d-cb5d3925db79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glasbey\n",
+    "import seaborn as sns\n",
+    "\n",
+    "sns.set()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e972edb-3033-46e8-a20b-63d3d2c5578a",
+   "metadata": {},
+   "source": [
+    "The most basic option, available in all the standard `glasbey` functions (`create_palette`, `extend_palette` and `create_block_palette`), is to set the option `colorblind_safe=True`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "75661a01-b2bd-4179-a779-1be7f6ebac2a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAABhCAYAAADiKT2SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE8ElEQVR4nO3asW+UdRzH8U+P80ybKwSKUrA1xpG69GYnEgcSnQgTG/+CTgQ3w6SrI5NOhI2ERBMHExOmNibCYmKEnkDVlkobKNfrPf4LDxpzfvX1mp/hkyfPc/d7526maZomAAAAUFRn2gMAAADg7xC2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAErrtr2waZJfdpKDyT+45j/mzOhBeovLGT3eSDMeT3tOCTPdbl5dXE4ev0jGHra2HjSHWV7uZ2NjL+NxM+05JXS7M1le7mf3cCOH8X629WznaM4sLOTh1lbGE/etjW6nmzMLJ/PoIJ60l9AdP83p2fk8er6bcXM47TkldGeO5PTsfLY2NjJx7mit230tx5f7ebKxl0Nnj1aOdDs5vtzP/sZ2mrH3s625xdlktp8830smzmutzPWTTrvfYmeapml9V9/9LPn+l78863/nzv1BVm6u5e6FQZ7dW5/2nBLmzq5m5eZacuFOcm932nPKGMzuZG3tYgaDG1lf/33ac0pYXT2ZtbWLub45yOaB97Otbz//MLevfZrzVz7KDz//NO05Jbzz1tu5fe3TvP9jcnd/2mvqWPntem6du5z3v7meu39sTntOCSvHTuXWucu5Mhjk53Wfa22dXf0iV9cu5ZPBl3mw/uu055Tw5urrubp2Kd8NPs7T9fvTnlPG+a8+SN67mHx9I9lxXmvl/KWkf7TVpf6KDAAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNJmmqZp2l78cCd5cfgPrvmPeWM8TO/UUkabw0xGo2nPKaHT66V3ainZ3E9Gk2nPKWM4M8nSUj/D4V5G7lsrvV4nS0v97I6HGcf72db+02M5fWIhj7a3MhofTHtOCb3uKzl9YiGPD5JR629ceoe7WZydz+PnuxlNxtOeU0Kv083i7Hy2h8OMnTtae6X3Wo4vzefJcDdj36GtdHudHF+az/5wO5OR97OtucW5ZK6fPNtLJp61Vub6Safdb7EvFbYAAADwb+OvyAAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACU9ifyAOixafyNWQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1200x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.create_palette(palette_size=12, colorblind_safe=True)\n",
+    "sns.palplot(palette)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "748e89c4-317d-4b96-9714-7d758d928260",
+   "metadata": {},
+   "source": [
+    "Note how the resulting palette selects reds and blues first, before eventually selecting greens, but attempts to use lightness contrast among those to make them more distinguishable. The default `colorblind_safe=True` options simulates only mild colour vision deficiency of the most common variety. To be robust against more severe cases of colour vision deficiency you can use the `cvd_severity` option, which takes values between 0, for essentially no deficiency, through to 100, which represents the most severe cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "aca841bf-08c4-4d3f-a264-f6ffd30d51da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAABhCAYAAADiKT2SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE4klEQVR4nO3azYuVdRjH4e85c5zRMZDGoRlnnAhbBSE4oFvXoetatQvc2DoIAlfugsJoHbRy1SaxretoBCmkJExnxrfR0akcnDkvT//CYyGnW69r/Vvc3DwvfM55Ok3TNAEAAICiuuMeAAAAAP4LYQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgtF7bg02TbDxJBqMXOM1L5uCz25lcWMrundU0g8G4xymh0+tlcmEpa6tJ38paO7KwmkwtJTurSWNxrXR6aaaW0mxse7A9hz9HOzmweDBb648ysrdWur1uDiwezObqaobeBa3t7pvL4vx01u9tZzB0rbXRm+hmcX5/7o4SV1p7+/qPMjs1k4c7mxk0rrU2ep1uZqdm8mDrUYbD4bjHKWO+P5vOXDfN/VEybMY9TgmduYl0ep12Z5umab3VM58nN9b/9VyvnC+uL+fo5ZVce285T3++Ou5xStj/7rEcvbySE8uDXLWy1vo/nUiWV5KV5eSpxbWy/1iyvJLtM5cyurE57mnK+GZ4PWevnM9XJz/NnWt/jHucEhaOvpWzV87ns+Xl3PJga+3W+9/nysVTOfnBpVy77h5t4+g7M7ly8VROP05+0Rqtnb55LheOn8vHP57L73/fHvc4Jbz92pu5cPxcPvryk/y2fnPc45Txw92vM/3tbLY/fJjRr35+amP6u9l0F9v9F+tTZAAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJTWaZqmaXt440nSH77AaV4yB3fXMnXocHburqXZ3R33OCV0Jiczdehw1tea7FhZa0cW15Opw8nOWjKyuFa6k8nU4Yw2tj3YnsNf6efAwky27mxmuDsY9zglTEz2cmBhJptraxl4F7Q22D+fhbnp3Lm/nV33aCuTeyayMDede8PEldbedP9xZve+nofPHqffeK61safTy+ze17Ox9Sj9gZ21NT+cTfeNiYweDJN+6wR7pXXmJtLpddqdfZ6wBQAAgP8bnyIDAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUNo/PYPssbYBiwwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1200x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.create_palette(palette_size=12, colorblind_safe=True, cvd_severity=100)\n",
+    "sns.palplot(palette)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29c0dbd3-6d73-401e-beec-aaf386f7d154",
+   "metadata": {},
+   "source": [
+    "Note that this biasing of palette choices may make the resulting palette less accessible to those without colour vision deficiency than it might otherwise be -- since the options for colour choices are more constrained.\n",
+    "\n",
+    "It is also possible to create a palette using simulations of other types of colour vision deficiency. The default option is the most common type: \"deuteranomaly\", but the `cvd_type` option can be used to specify \"protanomaly\" or \"tritanomaly\" which are a more rare red-green colorblindness, and an extremely rare blue-yellow colorblindness."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0c158fe0-8def-4553-9380-5ce19e929f91",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAABhCAYAAADiKT2SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE8ElEQVR4nO3aQYvUdRzH8c/OzK7S5tay66zCDoRFCJ1csEuHjhEEgUdP3cKoJ9BTiIIQ9JgQSJc6+RQ6BbsgFVLZoV1ddQ3dcU2dndl/T+FfIdNXX6/z7/Dly/yG33uYmaZpmgAAAEBRnWkPAAAAAP+FsAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQWq/twaZJ9m8mzfhpjvNsuffyH1lZGOT2cDPjicW10ev2svLSIPvZTBM7a6u3209nYT4Hw4fJ5GDa49TQ7aSzMJ/tzd1MxpNpT1PG3JFJ+stHc+fuTsb21kqv101/+WhujO5n3LifbQ2ylM6h5OBJkmba0xQxk3QONXm8NUyz7362NTy8l5Xjg9ze3sx47O3RRq/Xy8rxQXb2JhkfuKBtjXe7GQxmsrnZZDy2tzYGg05mZ2danZ1pmqb1Vq+9mzz68V/P9dz57NO1XD63nrMX13Jte2Pa45Rw8vipXD63nmtZy6PYWVuvXPw2i+fO5N7F7zLZ/nPa45TQPb6UxXNn8v7al/l548a0xynjrY/3cun8hXzwyUf55fpv0x6nhNdffS2Xzl/I21c/z9WHPmtt/d77Iounk3s/JJO9aU9TQ/fFZPF08v2bFzPc2J72OGV8/c6VXL6ynrPvreXaT94ebZx841QuX1nPh9/czK87o2mPU8b9r5ayvn4ka2sPsrHhx6c2rl8/khMnuq3O+isyAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAASptpmqZpe3i0nTSjpznOs2V3cSv9hdXcGW5lNLa4NuZ6c+kvrGaUrTSxs7Z6w5V0F+YzGT5MxpNpj1NDr5vuwnxube1mfzSe9jRlHFpo0l9ezp27d7O/vz/tcUqYnZ1Nf3k5N5/cz6hxP9saZCndw8nkcZLWL5Xn3EzSPZw8vjHMwRPfa23tvfBX+sdWc+fWVkYjb4825ubm0j+2mp29cfYnLmhbBw+6WV3tZGvrIKORvbUxGHQyOzvT6uw/ClsAAAD4v/FXZAAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABK+xthru2xd4y1BQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1200x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.create_palette(\n",
+    "    palette_size=12, \n",
+    "    colorblind_safe=True, \n",
+    "    cvd_type=\"protanomaly\",\n",
+    "    cvd_severity=100\n",
+    ")\n",
+    "sns.palplot(palette)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "43cc6110-0a61-4404-8883-c28a5acf9924",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7YAAABhCAYAAADiKT2SAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAE5klEQVR4nO3aMWtdZRzH8V9yb6NS0/bSiJre6+AgOAgmg9BZ6Fg3HS1F0NFBwULdRBeHIuJS7FsQnMTRpdAhKQoqLRQ0N20a24YmtGpyb45D38BRKcd//XzmM/x4OA/3fuHMNE3TBAAAAIqa7XoAAAAA/BvCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBp/bYPNk2TvbXNZDJ5mHseKRtHFjMaJGtbyWS/6zU19GeT0SDZHu9lf9J0PaeMSW8zC6Nhbq2NM53sdT2nhF7/QBZGozR3k8b9bG3jcLI4m1zfT/watNNPsjjbZPv+WvYbp9bWztZCRsP5rI13MplMu55TQr/fy2g4n80765lMvWttHe7P5uBglHtba2mcWyszvX4ODkbZ3LiR6dT9bOvJx0eZP5rs3E68au0cWkh6LYt1pmma1vVwdflU/li98k93/e+8+fF3WTnTz/Ink6yudb2mhqVRsnKmn/PHf87G5d+7nlPG7RffzrmVS3l3+ZVcW13tek4Jzy8t5dzKpex8nkyvd72mjtffT74dJCe2kh/8l2nlpd6DMzv/zXI2ttzPtr767MusXDyd5eMXsnr5ZtdzSlh6+emsXDydUx++miu/fN/1nDI+eGGUk2dX8vVHy7n9qzvaxtHnlnLy7EreeuO1XPnpx67nlHHqxNWc/jS58F5y81rXa2p454tk8Ey7Z32KDAAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJQmbAEAAChN2AIAAFCasAUAAKA0YQsAAEBpwhYAAIDShC0AAAClCVsAAABKE7YAAACUJmwBAAAoTdgCAABQmrAFAACgNGELAABAacIWAACA0oQtAAAApQlbAAAAShO2AAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNJmmqZp2j68N95Ms7v3MPc8UjYHixkOZjLearI77XpNDXO9ZDiYyfb6bqa7rV/N/73pgVtZGB7LrfF6Jrt/dj2nhP7cY1kYHsv+3aRxP1vbPJw820tuTJPdrscUMZcHZ7Z9f5zpvlNr697dpzI8Np/x+k52dyddzylhbq6f4bH5bN65nr2Jd62tIwf6OTgY5t7WOPvOrZXZ/lwODob57eZG9va0QVvzT4wyfzTZuZ1MHFsrhxaSXr/ds38rbAEAAOC/xqfIAAAAlCZsAQAAKE3YAgAAUJqwBQAAoDRhCwAAQGnCFgAAgNKELQAAAKUJWwAAAEoTtgAAAJT2F2J75bEcLfWnAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 1200x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.create_palette(\n",
+    "    palette_size=12, \n",
+    "    colorblind_safe=True, \n",
+    "    cvd_type=\"tritanomaly\",\n",
+    "    cvd_severity=100\n",
+    ")\n",
+    "sns.palplot(palette)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38313a51-1cfa-4aff-8ebe-1adeb98100fd",
+   "metadata": {},
+   "source": [
+    "These same options apply to the `extend_palette` and `create_block_palette` functions, although in those cases there are other colours involved (from the source palette, or the range of colours selected in a block) that make the problem even more challenging."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "99323052-8101-40a9-9519-c968e5830883",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABJ4AAABhCAYAAACXmGs1AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAGAklEQVR4nO3bzYtddx3H8c+5985MmmSmkUmamUQLQVFoUTFgceVGCoJQRKG74jLQhS71HxDqMl0IWRZXLlpoRBCKm7qRCBGVtAiVCDWZSZuHzmPn4d57/BNyin45nOb1Wp/Fh8vvnnPuG27Ttm0bAAAAAPg/G/U9AAAAAIDPJ+EJAAAAgBLCEwAAAAAlhCcAAAAASghPAAAAAJQQngAAAAAoITwBAAAAUEJ4AgAAAKCE8AQAAABAiUnXC9u2zcbWQaaztnLP58qzk4fJysVk+04yn/Y9ZxhGk7QrF7O5v5nZfNb3msE4vzvOZG0t083NtFNnrYtmMslkbS27jw4zd1/rrGl2s7x6NjsP7mc+8x3tYjQeZ3n1bGZbh4mz1t24yfjppWxvb2c+n/e9ZhBGo1FWVlZyeLiRtvUs6KppJllaWs/dw+NMW9/RLiZNkwtLC9n/+MO0M2etq2Y8yclzX8r00720c2eti2bUZPLU6dw5TKYeBZ1NRsnFpTY7h0eZu691MmqaLC8tZmv/Y79DP4Mzp85lPHp8VmratvtJ/MHrf8qtu9v/07Anyb8v/Sq58m5y7bvJxt/6njMM699Mrrybl3/3ct5/+H7fawbj+ttfzaW33sztH/04B++91/ecQTjx3HO59Nab+e0vb+T+h7t9zxmMlTNv55XXruY3v/hZPrr9r77nDMIzl76cV167mnuv38zx3b2+5wzGwoVTOf/Ty7l27Vo2Njb6njMI6+vruXLlSm7ceCk7u7f6njMYy6efzwsvXM+Lf/ln/rH7ad9zBuHrp5/KO9/+Wv7w6uU8+uCvfc8ZjC985Vv5/q9v5vY713P4yYO+5wzC0pnVXHrxpXzvz8nfd/peMxzfWE7++J3kjZu38tHeft9zBuGZUyfzk8vP5+rvX82dhx/0PWcwfv7DN7K6vP7Y6/zVDgAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJZq2bduuF29ufZqjaefLn3jPLnySrFxItu8ms6O+5wzDeDFZuZB7e/dyPD/ue81gnN9byMLa+Rxv3kt77Kx10SwsZmHtfHYfHWTmvtbZaLSX5dWz2XlwP7PptO85gzCeTLK8ejbTrcNkOu97znBMRpk8vZTt7e3MZrO+1wzCeDzOyspKDg4207aeBV01zWJOnFjLxsFRjrq/Fj/RFpsm6ycWs3//P5l77+hstLCYk2e/mOP9vbRzz4MumtEoCydP5e5BcuQj62xxlFw4kewcHmXmrHUyHo2yvLSYrf37mc78Du3qzKlzGY8mj73uM4UnAAAAAOjKX+0AAAAAKCE8AQAAAFBCeAIAAACghPAEAAAAQAnhCQAAAIASwhMAAAAAJYQnAAAAAEoITwAAAACUEJ4AAAAAKPFf3nQewLrCvjsAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1500x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.extend_palette(\n",
+    "    \"tab10\", \n",
+    "    palette_size=15, \n",
+    "    colorblind_safe=True, \n",
+    "    cvd_severity=100\n",
+    ")\n",
+    "sns.palplot(palette)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6c8b5043-34c2-49b4-83a5-804a0a76b68f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABFEAAABhCAYAAAAeLD4ZAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/NK7nSAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAFmUlEQVR4nO3bT4icdx3H8c/MTmd3lu7ubLJIk90KehJDKUZQsGDBP4gFPYmX3jx4EKU5RBCx1III0oABL97Fox56EHIRKvTioWmQUi9RcGeT1G7d2W6TbScz83joXb4RysPTvF7n5/DhxwM/njc8vaZpmgAAAADwP/XbHgAAAADQBSIKAAAAQIGIAgAAAFAgogAAAAAUiCgAAAAABSIKAAAAQIGIAgAAAFAgogAAAAAUiCgAAAAABYPqg03TZP/ONPP54qPc87EyHG1k9+wwB+/MMl80bc/phMFKL7tnV3P4buJVq9teS1ZHyQenSeNVK+n1ktVRk8P9t7PwspVtrK1l/dw4925Ps3RuJf3BStbPjbM8PkmzXLY9pzOO3jvJzuN7OdyfZDGftz2nE1YGg+w8vpf3J/tZOrOy0Xg1vfH5NNNbydK5lfQH6Y3PZzq54y54AOPNrfTPPJrlf95L3Ac1/X76Zx7N3clRlnNnVrUx3kzGjyTT+4nv0JrtYXorvdKjvaapf3Jd/M5Luf7m5P/e9bD58je/n1euXMjTl9/IjX/ea3tOJzz5qfW8cuVCfvTb5Obtttd0x8+fTr7wleSvf05Ojtte0w0bWx+e2XMXf5ib12+2PaczfvCtr+aZly/nT9++kqM33AcV2xf28szLl/P2b36X+a1/tz2nM3517Y+5+tqruXTxqfzj+o2253TCpz/3ZK6+9mr+8tTnc3zjettzOuNrv/h6Rpeu5fTqN7I8+Fvbczqhv/tERpeu5ddf/G4OXn+z7Tmd8bOf/iTjF57N9MXfZ/Ev90HFyic/kfELz+YPX/plDl/fb3tOZ3zvxefyyI8/k/sv/T2ZnLY9pxMGz382vZ3V0rN+5wEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACkQUAAAAgAIRBQAAAKBARAEAAAAoEFEAAAAACnpN0zTVhydvTTObzT/KPR8ra+ubOX92mFvvzDKbL9ue0wnDQT/nzw5z+G5y36tWtj1K1kbJ+6dJ41Ur6fU/PLPDyWHms/ttz+mMzfVR1h8b596daRbug5KV4SDrj42zOD5Js1i0PaczpvfuZmdvN4eTg8xns7bndMJgOMzO3m5ODyZZOrOy0ZlR+lvnsjy+ncydW8lgmP7WuRwfvOUOfQDj8VZWtjeyODpJfBvUDPpZ2d7I3YOjLGbu0KqN7c30xsM001kyL3/uP9y2h+mt9EqPPlBEAQAAAHhY+Z0HAAAAoEBEAQAAACgQUQAAAAAKRBQAAACAAhEFAAAAoEBEAQAAACgQUQAAAAAKRBQAAACAAhEFAAAAoOC/NFoFwL4yoq8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1400x100 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "palette = glasbey.create_block_palette(\n",
+    "    [4, 3, 3, 2, 2],\n",
+    "    colorblind_safe=True, \n",
+    "    cvd_severity=100\n",
+    ")\n",
+    "sns.palplot(palette)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "glasbey_dev",
+   "language": "python",
+   "name": "conda-env-glasbey_dev-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,10 +32,19 @@ master_doc = "index"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "numpydoc",
     "nbsphinx",
     "sphinx.ext.mathjax",
 ]
+
+# this is needed for some reason...
+# see https://github.com/numpy/numpydoc/issues/69
+numpydoc_show_class_members = False
+
+autodoc_default_flags = ['members', 'inherited-members']
+autosummary_generate = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,8 @@ User Guide
    creating_palettes
    extending_palettes
    creating_block_palettes
-
+   color_vision_deficiency
+   api
 
 ----------------
 Acknowledgements

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,3 +6,4 @@ numpy>=1.21
 numba>=0.56
 colorspacious>=1.1
 matplotlib>=3.5
+numpydoc

--- a/glasbey/_internals.py
+++ b/glasbey/_internals.py
@@ -92,3 +92,159 @@ def generate_next_color_cam02ucs(colors, current_distances, new_palette_block):
     result = get_next_color(current_distances, colors, new_palette_block[0])
 
     return result
+
+
+@numba.njit(
+    [
+        "UniTuple(f4[::1], 2)(f4[::1], f4[:, ::1], f4[:, ::1], f4[::1], f4[::1], f4)",
+        numba.types.UniTuple(
+            numba.types.Array(numba.float32, 1, "C", readonly=True), 2
+        )(
+            numba.types.Array(numba.float32, 1, "C"),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 1, "C", readonly=True),
+            numba.types.Array(numba.float32, 1, "C", readonly=True),
+            numba.float32,
+        ),
+    ],
+    locals={
+        "diff": numba.float32,
+        "d1": numba.float32,
+        "d2": numba.float32,
+        "d": numba.float32,
+        "dim": numba.intp,
+        "i": numba.uint32,
+    },
+    fastmath=True,
+    nogil=True,
+    boundscheck=False,
+)
+def two_space_get_next_color(
+    distances, colors1, colors2, new_color1, new_color2, alpha=0.0
+):
+    argmax = -1
+    max_dist = 0.0
+    dim = distances.shape[0]
+    for i in range(dim):
+
+        # Color space 1 distance
+        d1 = 0.0
+        if alpha > 0.0:
+            for j in range(3):
+                diff = colors1[i, j] - new_color1[j]
+                d1 += diff * diff
+
+        # Color space 2 distance
+        d2 = 0.0
+        if alpha < 1.0:
+            for j in range(colors2.shape[1]):
+                diff = colors2[i, j] - new_color2[j]
+                d2 += diff * diff
+
+        # Combined distance
+        d = alpha * d1 + (1.0 - alpha) * d2
+
+        if d < distances[i]:
+            distances[i] = d
+        if distances[i] > max_dist:
+            max_dist = distances[i]
+            argmax = i
+
+    return colors1[argmax], colors2[argmax]
+
+
+@numba.njit(
+    [
+        "f4[:,::1](f4[:,::1], f4[:,::1], f4[:,::1], f4[:,::1], i4, f4)",
+        numba.types.Array(numba.float32, 2, "C")(
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.uint32,
+            numba.float32,
+        ),
+    ],
+    locals={
+        "distances": numba.types.Array(numba.float32, 1, "C"),
+        "initial_palette_size": numba.uint16,
+        "i": numba.uint16,
+    },
+)
+def generate_palette_cam02ucs_and_other(
+    colors1, colors2, initial_palette1, initial_palette2, size, alpha=0.0
+):
+    distances = np.full(colors1.shape[0], fill_value=1e12, dtype=np.float32)
+    result = np.empty((size, 3), dtype=np.float32)
+    initial_palette_size = np.uint16(initial_palette1.shape[0])
+    result[:initial_palette_size] = initial_palette1
+
+    for i in range(initial_palette_size):
+        _ = two_space_get_next_color(
+            distances,
+            colors1,
+            colors2,
+            result[i],
+            initial_palette2[i],
+            alpha=alpha,
+        )
+
+    next_color_other_space = initial_palette2[-1]
+
+    for i in range(initial_palette_size, size):
+        result[i], next_color_other_space = two_space_get_next_color(
+            distances,
+            colors1,
+            colors2,
+            result[i - 1],
+            next_color_other_space,
+            alpha=alpha,
+        )
+
+    return result
+
+
+@numba.njit(
+    [
+        numba.types.Array(numba.float32, 1, "C", readonly=True)(
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 1, "C"),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.types.Array(numba.float32, 2, "C", readonly=True),
+            numba.float32,
+        )
+    ],
+    locals={
+        "i": numba.uint16,
+    },
+)
+def generate_next_color_cam02ucs_and_other(
+    colors1,
+    colors2,
+    current_distances,
+    new_palette_block1,
+    new_palette_block2,
+    alpha=0.0,
+):
+    for i in range(new_palette_block1.shape[0]):
+        _ = two_space_get_next_color(
+            current_distances,
+            colors1,
+            colors2,
+            new_palette_block1[i],
+            new_palette_block2[i],
+            alpha=alpha,
+        )
+
+    result, _ = two_space_get_next_color(
+        current_distances,
+        colors1,
+        colors2,
+        new_palette_block1[0],
+        new_palette_block2[0],
+        alpha=alpha,
+    )
+
+    return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = glasbey
-version = 0.1.0
+version = 0.2.0
 author = Leland McInnes
 author_email = leland.mcinnes@gmail.com
 maintainer = Leland McInnes


### PR DESCRIPTION
We measure distance in CAM02-UCS between a grid transformed in a simulation of colour deficient vision in order to maximize distance to the closest colour in the existing palette. This should aid in the creation of palettes more suitable for individuals with colour deficient vision.