### PR TITLE
[draft]: remove matplotlib dependency

### DIFF
--- a/glasbey/_glasbey.py
+++ b/glasbey/_glasbey.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from colorspacious import cspace_convert
-from matplotlib.colors import rgb2hex, to_rgb, LinearSegmentedColormap
 from sklearn.neighbors import NearestNeighbors
 
 from ._grids import rgb_grid, jch_grid, constrain_by_lightness_chroma_hue
@@ -14,7 +13,7 @@ from ._internals import (
     generate_palette_cam02ucs_and_other,
     two_space_get_next_color,
 )
-from ._converters import get_rgb_palette, palette_to_sRGB1
+from ._converters import get_rgb_palette, palette_to_sRGB1, to_rgb
 from ._optimizers import optimize_endpoint_color
 
 from typing import *
@@ -369,7 +368,7 @@ def extend_palette(
 
 
 def create_theme_palette(
-    base_color,
+    base_color: Union[str, Tuple[float, float, float]],
     palette_size: int = 5,
     *,
     color_grid: Optional[np.ndarray] = None,

--- a/glasbey/tests/test_converters.py
+++ b/glasbey/tests/test_converters.py
@@ -1,17 +1,15 @@
 import pytest
 import numpy as np
 
-from glasbey._converters import get_rgb_palette, palette_to_sRGB1
-from matplotlib.cm import get_cmap
-from matplotlib.colors import to_rgb
+from glasbey._converters import get_rgb_palette, palette_to_sRGB1, to_rgb
 from colorspacious import cspace_convert
 
+try:
+    from matplotlib.cm import get_cmap
+except ImportError:
+    get_cmap = None
 
-TAB10 = get_cmap("tab10", 10).colors[:, :3]
-SET1 = get_cmap("Set1", 6).colors[:, :3]
-ACCENT = get_cmap("Accent", 6).colors[:, :3]
-
-
+@pytest.mark.skipif(get_cmap is None, reason="matplotlib is not installed")
 @pytest.mark.parametrize("palette", ["tab10", "Set1", "Accent"])
 def test_palette_conversion(palette):
     pal = get_cmap(palette, 6).colors[:, :3]
@@ -23,9 +21,10 @@ def test_palette_conversion(palette):
 
 @pytest.mark.parametrize(
     "palette",
-    ["tab10", "Set1", "#836fa9", ["#836fa9", "#3264c8"], [(0.1, 0.75, 0.3)], [(128, 192, 255), (16, 32, 64)]]
+    ["#836fa9", ["#836fa9", "#3264c8"], [(0.1, 0.75, 0.3)], [(128, 192, 255), (16, 32, 64)]]
 )
 def test_srgb1_conversion(palette):
+
     srgb1_pal = palette_to_sRGB1(palette)
     assert srgb1_pal.shape[1] == 3
     assert np.max(srgb1_pal) <= 1.0 and np.min(srgb1_pal) >= 0.0
@@ -39,3 +38,18 @@ def test_srgb1_conversion(palette):
             assert np.allclose(pal, srgb1_pal)
     else:
         assert len(palette) == len(srgb1_pal)
+
+
+@pytest.mark.parametrize("palette", ["tab10", "Set1"])
+def test_srgb1_conversion_mpl(palette):
+    if get_cmap is None:
+        with pytest.raises(ValueError, match="Unrecognized palette name"):
+            palette_to_sRGB1(palette)
+        return
+
+    srgb1_pal = palette_to_sRGB1(palette)
+    assert srgb1_pal.shape[1] == 3
+    assert np.max(srgb1_pal) <= 1.0 and np.min(srgb1_pal) >= 0.0
+    pal = np.asarray(get_cmap(palette).colors)[:, :3]
+    assert len(pal) == len(srgb1_pal)
+    assert np.allclose(pal, srgb1_pal)

--- a/glasbey/tests/test_glasbey.py
+++ b/glasbey/tests/test_glasbey.py
@@ -2,18 +2,20 @@ import pytest
 import numpy as np
 
 from colorspacious import cspace_convert
-from matplotlib.colors import to_rgb
-from matplotlib.cm import get_cmap
 from glasbey._glasbey import (
     create_palette,
     create_theme_palette,
     create_block_palette,
     extend_palette,
 )
-from glasbey._converters import palette_to_sRGB1
+from glasbey._converters import palette_to_sRGB1, to_rgb
 
 from typing import *
 
+try:
+    from matplotlib.cm import get_cmap
+except ImportError:
+    get_cmap = None
 
 @pytest.mark.parametrize("grid_size", [32, 64, (32, 32, 128)])
 @pytest.mark.parametrize("grid_space", ["RGB", "JCh"])
@@ -33,7 +35,7 @@ def test_create_palette_distances(grid_size, grid_space: Literal["RGB", "JCh"]):
 
         assert prev_min_dist >= current_min_dist
 
-
+@pytest.mark.skipif(get_cmap is None, reason="matplotlib is not installed")
 @pytest.mark.parametrize("grid_size", [32, 64, (32, 32, 128)])
 @pytest.mark.parametrize("grid_space", ["RGB", "JCh"])
 @pytest.mark.parametrize("palette_to_extend", ["tab10", "Accent", "Set1", "#3264c8"])
@@ -56,7 +58,7 @@ def test_extend_palette_distances(
 
         assert prev_min_dist >= current_min_dist
 
-
+@pytest.mark.skipif(get_cmap is None, reason="matplotlib is not installed")
 @pytest.mark.parametrize("grid_size", [32, 64, (32, 32, 128)])
 @pytest.mark.parametrize("grid_space", ["RGB"])
 @pytest.mark.parametrize("palette_to_extend", ["tab10", "Accent", "Set1"])
@@ -145,6 +147,7 @@ def test_create_palette_colorblind_safe():
     assert np.all((jch_pal[:, 2] < 90) | (jch_pal[:, 2] > 240))
 
 
+@pytest.mark.skipif(get_cmap is None, reason="matplotlib is not installed")
 @pytest.mark.parametrize("palette_to_extend", ["tab10", "Set1", "Pastel1"])
 def test_extend_palette_colorblind_safe(palette_to_extend):
     orig_palette = palette_to_sRGB1(palette_to_extend)


### PR DESCRIPTION
well, here's a minimal example of making mpl optional.  Though, I later noticed that scikit-learn is also coming in, and that's also more than I would want to bring in in cmap, so this might not be so easy afterall

while this does allow all your tests pass without mpl (except those that explicitly need a colormap with get_cmap), i'll note the obvious reduction in support for all the many color formats that matplotlib supports if someone passes in a color that is neither a hex string or a sequence of numbers.

An alternative to this (that I guess I'm leaning towards again) is for me to just vendor the bits of glasbey that I want over in cmap (which is mostly `create_palette`, which doesn't need the sklearn nearest neighbors or get_cmap functionality of the extension functions).  Would you rather I did that (and credit you and the original package of course) rather than muck about too much with your package here?